### PR TITLE
version bump.

### DIFF
--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_ucsf';
-$plugin->version = 2025021403;
+$plugin->version = 2025021404;
 $plugin->release = 'v4.5.2';
 $plugin->requires = 2024100100;
 $plugin->supported = [405, 405];


### PR DESCRIPTION
just a version bump so we can ship a proper release of the [recent linting fixes](https://github.com/ucsf-education/moodle-theme-ucsf/pull/208).

this will help us to integrate these changes into the CLE, since our hand is now forced by dependabot on this.