### PR TITLE
prevent input controls from running into each other on smaller screens.

### DIFF
--- a/classes/admin_setting_daterange.php
+++ b/classes/admin_setting_daterange.php
@@ -163,36 +163,34 @@ class admin_setting_daterange extends admin_setting {
             $enddate = $data[self::END_DATE];
         }
 
-        $return = html_writer::start_div('row mb-1');
+        $return = html_writer::start_div('row justify-column-start mb-1');
         $return .= html_writer::label(
             get_string('startdate', 'theme_ucsf'),
             $this->get_id() . '_' . self::START_DATE,
-            attributes: ['class' => 'col-form-label text-sm-end col-sm-1'],
+            attributes: ['class' => 'col-form-label col-md-1 text-md-end'],
         );
-        $return .= html_writer::start_div('col-sm-11');
+        $return .= html_writer::start_div('col-md-6 col-lg-4');
         $return .= html_writer::empty_tag('input', [
                 'class' => 'form-control text-ltr',
                 'id' => $this->get_id() . '_' . self::START_DATE,
                 'name' => $this->get_full_name() . '[' . self::START_DATE . ']',
-                'size' => '15',
                 'value' => s($startdate),
                 'type' => 'date',
         ]);
         $return .= html_writer::end_div();
         $return .= html_writer::end_div();
 
-        $return .= html_writer::start_div('row');
+        $return .= html_writer::start_div('row justify-content-start');
         $return .= html_writer::label(
             get_string('enddate', 'theme_ucsf'),
             $this->get_id() . '_' . self::END_DATE,
-            attributes: ['class' => 'col-form-label text-sm-end col-sm-1'],
+            attributes: ['class' => 'col-form-label col-md-1 text-md-end'],
         );
-        $return .= html_writer::start_div('col-sm-11');
+        $return .= html_writer::start_div('col-md-6 col-lg-4');
         $return .= html_writer::empty_tag('input', [
                 'class' => 'form-control text-ltr',
                 'id' => $this->get_id() . '_' . self::END_DATE,
                 'name' => $this->get_full_name() . '[' . self::END_DATE . ']',
-                'size' => '15',
                 'value' => s($enddate),
                 'type' => 'date',
         ]);

--- a/classes/admin_setting_datetimerange.php
+++ b/classes/admin_setting_datetimerange.php
@@ -268,19 +268,18 @@ class admin_setting_datetimerange extends admin_setting {
             $endminute = $data[self::END_MINUTE];
         }
 
-        $return = html_writer::start_div('row mb-1');
+        $return = html_writer::start_div('row justify-column-start mb-1');
         $return .= html_writer::label(
             get_string('startdate', 'theme_ucsf'),
             $this->get_id() . '_' . self::START_DATE,
-            attributes: ['class' => 'col-form-label text-sm-end col-sm-1'],
+            attributes: ['class' => 'col-form-label col-lg-1 text-lg-end'],
         );
-        $return .= html_writer::start_div('col-sm-2');
+        $return .= html_writer::start_div('col-lg-4');
         $return .= html_writer::empty_tag('input', [
                 'aria-label' => get_string('startdate', 'theme_ucsf'),
                 'class' => 'form-control text-ltr',
                 'id' => $this->get_id() . '_' . self::START_DATE,
                 'name' => $this->get_full_name() . '[' . self::START_DATE . ']',
-                'size' => '15',
                 'value' => s($startdate),
                 'type' => 'date',
         ]);
@@ -288,9 +287,9 @@ class admin_setting_datetimerange extends admin_setting {
         $return .= html_writer::label(
             get_string('start_hour', 'theme_ucsf'),
             $this->get_id() . '_' . self::START_HOUR,
-            attributes: ['class' => 'col-form-label text-sm-end col-sm-1'],
+            attributes: ['class' => 'col-form-label col-lg-1 text-lg-end'],
         );
-        $return .= html_writer::start_div('col-sm-1');
+        $return .= html_writer::start_div('col-lg-2');
         $return .= html_writer::start_tag('select', [
                 'class' => 'form-select',
                 'id' => $this->get_id() . '_' . self::START_HOUR,
@@ -308,9 +307,9 @@ class admin_setting_datetimerange extends admin_setting {
         $return .= html_writer::label(
             get_string('start_minute', 'theme_ucsf'),
             $this->get_id() . '_' . self::START_MINUTE,
-            attributes: ['class' => 'col-form-label text-sm-end col-sm-2'],
+            attributes: ['class' => 'col-form-label col-lg-1 text-lg-end'],
         );
-        $return .= html_writer::start_div('col-sm-5');
+        $return .= html_writer::start_div('col-lg-2');
         $return .= html_writer::start_tag('select', [
                 'class' => 'form-select',
                 'id' => $this->get_id() . '_' . self::START_MINUTE,
@@ -327,18 +326,17 @@ class admin_setting_datetimerange extends admin_setting {
         $return .= html_writer::end_div();
         $return .= html_writer::end_div();
 
-        $return .= html_writer::start_div('row');
+        $return .= html_writer::start_div('row justify-column-start');
         $return .= html_writer::label(
             get_string('enddate', 'theme_ucsf'),
             $this->get_id() . '_' . self::END_DATE,
-            attributes: ['class' => 'col-form-label text-sm-end col-sm-1'],
+            attributes: ['class' => 'col-form-label col-lg-1 text-lg-end'],
         );
-        $return .= html_writer::start_div('col-sm-2');
+        $return .= html_writer::start_div('col-lg-4');
         $return .= html_writer::empty_tag('input', [
                 'class' => 'form-control text-ltr',
                 'id' => $this->get_id() . '_' . self::END_DATE,
                 'name' => $this->get_full_name() . '[' . self::END_DATE . ']',
-                'size' => '15',
                 'value' => s($enddate),
                 'type' => 'date',
         ]);
@@ -346,9 +344,9 @@ class admin_setting_datetimerange extends admin_setting {
         $return .= html_writer::label(
             get_string('end_hour', 'theme_ucsf'),
             $this->get_id() . '_' . self::END_HOUR,
-            attributes: ['class' => 'col-form-label text-sm-end col-sm-1'],
+            attributes: ['class' => 'col-form-label col-lg-1 text-lg-end'],
         );
-        $return .= html_writer::start_div('col-sm-1');
+        $return .= html_writer::start_div('col-lg-2');
         $return .= html_writer::start_tag('select', [
                 'class' => 'form-select',
                 'id' => $this->get_id() . '_' . self::END_HOUR,
@@ -366,9 +364,9 @@ class admin_setting_datetimerange extends admin_setting {
         $return .= html_writer::label(
             get_string('end_minute', 'theme_ucsf'),
             $this->get_id() . '_' . self::END_MINUTE,
-            attributes: ['class' => 'col-form-label text-sm-end col-sm-2'],
+            attributes: ['class' => 'col-form-label col-lg-1 text-lg-end'],
         );
-        $return .= html_writer::start_div('col-sm-1');
+        $return .= html_writer::start_div('col-lg-2');
         $return .= html_writer::start_tag('select', [
                 'class' => 'form-select',
                 'id' => $this->get_id() .  '_' . self::END_MINUTE,

--- a/classes/admin_setting_timerange.php
+++ b/classes/admin_setting_timerange.php
@@ -189,13 +189,13 @@ class admin_setting_timerange extends admin_setting {
             $endminute = $data[self::END_MINUTE];
         }
 
-        $return = html_writer::start_div('row mb-1');
+        $return = html_writer::start_div('row justify-column-start mb-1');
         $return .= html_writer::label(
             get_string('start_hour', 'theme_ucsf'),
             $this->get_id() . '_' . self::START_HOUR,
-            attributes: ['class' => 'col-form-label text-sm-end col-sm-1'],
+            attributes: ['class' => 'col-form-label col-md-1 text-md-end'],
         );
-        $return .= html_writer::start_div('col-sm-1');
+        $return .= html_writer::start_div('col-md-3 col-lg-2');
         $return .= html_writer::start_tag('select', [
                 'class' => 'form-select',
                 'id' => $this->get_id() . '_' . self::START_HOUR,
@@ -213,10 +213,10 @@ class admin_setting_timerange extends admin_setting {
         $return .= html_writer::label(
             get_string('start_minute', 'theme_ucsf'),
             $this->get_id() . '_' . self::START_MINUTE,
-            attributes: ['class' => 'col-form-label text-sm-end col-sm-2'],
+            attributes: ['class' => 'col-form-label col-md-1 text-md-end'],
         );
 
-        $return .= html_writer::start_div('col-sm-8');
+        $return .= html_writer::start_div('col-md-3 col-lg-2');
         $return .= html_writer::start_tag('select', [
                 'class' => 'form-select',
                 'id' => $this->get_id() . '_' . self::START_MINUTE,
@@ -233,13 +233,13 @@ class admin_setting_timerange extends admin_setting {
         $return .= html_writer::end_div();
         $return .= html_writer::end_div();
 
-        $return .= html_writer::start_div('row');
+        $return .= html_writer::start_div('row justify-column-start');
         $return .= html_writer::label(
             get_string('end_hour', 'theme_ucsf'),
             $this->get_id() . '_' . self::END_HOUR,
-            attributes: ['class' => 'col-form-label text-sm-end col-sm-1'],
+            attributes: ['class' => 'col-form-label col-md-1 text-md-end'],
         );
-        $return .= html_writer::start_div('col-sm-1');
+        $return .= html_writer::start_div('col-md-3 col-lg-2');
         $return .= html_writer::start_tag('select', [
                 'class' => 'form-select',
                 'id' => $this->get_id() . '_' . self::END_HOUR,
@@ -257,9 +257,9 @@ class admin_setting_timerange extends admin_setting {
         $return .= html_writer::label(
             get_string('end_minute', 'theme_ucsf'),
             $this->get_id() . '_' . self::END_MINUTE,
-            attributes: ['class' => 'col-form-label text-sm-end col-sm-2'],
+            attributes: ['class' => 'col-form-label col-md-1 text-md-end'],
         );
-        $return .= html_writer::start_div('col-sm-8');
+        $return .= html_writer::start_div('col-md-3 col-lg-2');
         $return .= html_writer::start_tag('select', [
                 'class' => 'form-select',
                 'id' => $this->get_id() . '_' . self::END_MINUTE,

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_ucsf';
-$plugin->version = 2026041700;
-$plugin->release = 'v5.1.0';
+$plugin->version = 2026041701;
+$plugin->release = 'v5.1.1';
 $plugin->requires = 2025092600;
 $plugin->supported = [501, 501];
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
fixes #215

# Combined Date/Time controls

## Large screens (992px+ width)

<img width="1023" height="502" alt="image" src="https://github.com/user-attachments/assets/e14d8857-69e7-43a0-ba17-cfd978963722" />

## Anything smaller

<img width="799" height="683" alt="image" src="https://github.com/user-attachments/assets/d33b387e-ffc5-4fd9-a9f5-de99ebd426a5" />


# Split Date/Time controls

## Large screens (992px+ width)

<img width="1017" height="652" alt="image" src="https://github.com/user-attachments/assets/19d347a4-13b9-4e66-b977-38d5fffe6dae" />

## Medium screens (768-991px width)

<img width="787" height="643" alt="image" src="https://github.com/user-attachments/assets/a69f3255-8987-4c2a-bd04-99b9f33f0bfc" />


## Anything smaller

<img width="616" height="640" alt="image" src="https://github.com/user-attachments/assets/31d4e978-b33b-48f5-99c1-73d2295e6064" />
