### PR TITLE
remove inclusion of non-existent javascript file, test with MariaDB 11 in CI pipeline.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,14 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
 
       mariadb:
-        image: mariadb:10
+        image: mariadb:11
         env:
-          MYSQL_USER: "root"
-          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
-          MYSQL_CHARACTER_SET_SERVER: "utf8mb4"
-          MYSQL_COLLATION_SERVER: "utf8mb4_unicode_ci"
+          MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: "yes"
+          MARIADB_CHARACTER_SET_SERVER: "utf8mb4"
+          MARIADB_COLLATION_SERVER: "utf8mb4_unicode_ci"
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
-
+        options: --health-cmd="mariadb-admin ping" --health-interval 10s --health-timeout 5s --health-retries 3
     strategy:
       fail-fast: false
       matrix:

--- a/layout/includes/javascript.php
+++ b/layout/includes/javascript.php
@@ -25,5 +25,4 @@ defined('MOODLE_INTERNAL') || die();
 
 $PAGE->requires->js_call_amd('theme_ucsf/usereditform', 'init');
 $PAGE->requires->js_call_amd('theme_ucsf/banneralerts', 'init');
-$PAGE->requires->js_call_amd('theme_ucsf/datepicker', 'init');
 $PAGE->requires->js_call_amd('theme_ucsf/backtotopbutton', 'init');

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_ucsf';
-$plugin->version = 2026041701;
-$plugin->release = 'v5.1.1';
+$plugin->version = 2026041702;
+$plugin->release = 'v5.1.2';
 $plugin->requires = 2025092600;
 $plugin->supported = [501, 501];
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
the custom datepicker was removed from the theme for the Moodle 5.1 update.

fixes #217 


also - let's test with MariaDB v11 in GHA.

fixes #219 