### PR TITLE
Adds test coverage for banner alerts output

### DIFF
--- a/classes/output/banneralerts.php
+++ b/classes/output/banneralerts.php
@@ -68,8 +68,8 @@ class banneralerts implements renderable, templatable {
         $obj->showalerts = false;
         $obj->url = $CFG->wwwroot . '/theme/ucsf/banneralerts.php';
 
-        // Alerts are only dismissable by logged-in users.
-        $dismissable = isloggedin();
+        // Alerts are only dismissible by logged-in users.
+        $dismissible = isloggedin();
 
         for ($i = 1; $i <= constants::BANNERALERT_ITEMS_COUNT; $i++) {
             // Skip if alert has already been flagged as seen in this user's session.
@@ -279,7 +279,7 @@ class banneralerts implements renderable, templatable {
                     'id' => $i,
                     'classes' => $alertclasses,
                     'message' => $alertmessage,
-                    'dismissable' => $dismissable,
+                    'dismissible' => $dismissible,
             ];
         }
         $obj->showalerts = !empty($obj->alerts);

--- a/classes/output/banneralerts.php
+++ b/classes/output/banneralerts.php
@@ -16,6 +16,7 @@
 
 namespace theme_ucsf\output;
 
+use core\clock;
 use DateTime;
 use dml_exception;
 use moodle_page;
@@ -38,6 +39,9 @@ class banneralerts implements renderable, templatable {
     /** @var moodle_page The current page. */
     protected moodle_page $page;
 
+    /** @var clock $clock Moodle's internal clock. */
+    protected clock $clock;
+
     /** @var string[] Maps alert levels to CSS classes. */
     const ALERT_LEVEL_CSS_CLASSES_MAP = [
             constants::BANNERALERT_LEVEL_INFORMATION => 'alert-info',
@@ -45,13 +49,21 @@ class banneralerts implements renderable, templatable {
             constants::BANNERALERT_LEVEL_WARNING => 'alert-danger',
     ];
 
+    /* @var moodle_page $page The current page. */
+
     /**
      * Class constructor.
      *
-     * @param moodle_page $page
+     * @param moodle_page $page The current page.
+     * @param clock $clock Moodle's internal clock.
+     * @var moodle_page $page The current page.
      */
-    public function __construct(moodle_page $page) {
+    public function __construct(
+        moodle_page $page,
+        clock $clock
+    ) {
         $this->page = $page;
+        $this->clock = $clock;
     }
 
     /**
@@ -137,7 +149,7 @@ class banneralerts implements renderable, templatable {
             // Check if this alert is within its given date/time boundaries.
             $alertiswithindatetimeboundaries = false;
 
-            $now = time();
+            $now = $this->clock->time();
             $today = strtotime("midnight", $now); // Start of today/"today at midnight".
 
             switch ($alerttype) {

--- a/layout/includes/banneralerts.php
+++ b/layout/includes/banneralerts.php
@@ -22,9 +22,13 @@
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use core\clock;
+use core\di;
 use theme_ucsf\output\banneralerts;
 
 defined('MOODLE_INTERNAL') || die();
 
-$banneralerts = new banneralerts($PAGE);
+$clock = di::get(clock::class);
+$banneralerts = new banneralerts($PAGE, $clock);
+
 $templatecontext['banneralerts'] = $OUTPUT->render($banneralerts);

--- a/templates/banneralerts.mustache
+++ b/templates/banneralerts.mustache
@@ -30,7 +30,7 @@
     <div class="ucsf-banneralerts-container row pt-3">
         {{#alerts}}
             <div class="col-12">
-                <div class="alert alert-block fade in alert-dismissible ucsf-banneralerts-alert {{classes}}"
+                <div class="alert alert-block fade in {{#dismissable}} alert-dismissible{{/dismissable}} ucsf-banneralerts-alert {{classes}}"
                      role="alert"
                      data-aria-autofocus="true"
                      data-ucsf-banneralerts-alert-id="{{id}}"

--- a/templates/banneralerts.mustache
+++ b/templates/banneralerts.mustache
@@ -19,8 +19,8 @@
     {
         "url": "http://localhost/theme/ucsf/banneralert.php",
         "alerts": [
-            { "id": "1", "classes": "alert-info", "message": "Lorem Ipsum", "dismissable": true },
-            { "id": "2", "classes": "alert-warning", "message": "Foo Bar Baz", "dismissable": false }
+            { "id": "1", "classes": "alert-info", "message": "Lorem Ipsum", "dismissible": true },
+            { "id": "2", "classes": "alert-warning", "message": "Foo Bar Baz", "dismissible": false }
         ],
         "showalerts": true
     }
@@ -30,17 +30,17 @@
     <div class="ucsf-banneralerts-container row pt-3">
         {{#alerts}}
             <div class="col-12">
-                <div class="alert alert-block fade in {{#dismissable}} alert-dismissible{{/dismissable}} ucsf-banneralerts-alert {{classes}}"
+                <div class="alert alert-block fade in {{#dismissible}} alert-dismissible{{/dismissible}} ucsf-banneralerts-alert {{classes}}"
                      role="alert"
                      data-aria-autofocus="true"
                      data-ucsf-banneralerts-alert-id="{{id}}"
                      data-ucsf-banneralert-dismiss-callback-url="{{url}}"
                 >
-                    {{#dismissable}}
+                    {{#dismissible}}
                         <button type="button" class="btn-close" data-bs-dismiss="alert">
                             <span class="visually-hidden">{{#str}}dismissmessage, theme_ucsf{{/str}}</span>
                         </button>
-                    {{/dismissable}}
+                    {{/dismissible}}
                     {{{message}}}
                 </div>
             </div>

--- a/templates/banneralerts.mustache
+++ b/templates/banneralerts.mustache
@@ -30,7 +30,7 @@
     <div class="ucsf-banneralerts-container row pt-3">
         {{#alerts}}
             <div class="col-12">
-                <div class="alert alert-block fade in {{#dismissible}} alert-dismissible{{/dismissible}} ucsf-banneralerts-alert {{classes}}"
+                <div class="alert alert-block fade in{{#dismissible}} alert-dismissible{{/dismissible}} ucsf-banneralerts-alert {{classes}}"
                      role="alert"
                      data-aria-autofocus="true"
                      data-ucsf-banneralerts-alert-id="{{id}}"

--- a/tests/behat/behat_theme_ucsf_behat_banneralerts.php
+++ b/tests/behat/behat_theme_ucsf_behat_banneralerts.php
@@ -89,6 +89,20 @@ class behat_theme_ucsf_behat_banneralerts extends behat_base {
     }
 
     /**
+     * Sets the target of a given banner alert to the given course category.
+     * @param string $alertid The banner alert id.
+     * @param string $categoryidnumber The course category id number.
+     */
+    #[Then('/^alert ([1-9]|10) targets course category "([^"]+)"$/')]
+    public function alert_x_targets_course_category_y(string $alertid, string $categoryidnumber): void {
+        $categoryid = $this->get_category_id($categoryidnumber);
+        if (!$categoryid) {
+            throw new Exception("Course category with idnumber '{$categoryidnumber}' does not exist.");
+        }
+        set_config("categories_list_alert{$alertid}", (string) $categoryid, 'theme_ucsf');
+    }
+
+    /**
      * Dismisses a banner alert with the given text.
      * @param string $text The alert text.
      */

--- a/tests/behat/behat_theme_ucsf_behat_banneralerts.php
+++ b/tests/behat/behat_theme_ucsf_behat_banneralerts.php
@@ -1,0 +1,129 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Theme UCSF - custom Behat rules for banner alerts.
+ *
+ * @package theme_ucsf
+ * @copyright The Regents of the University of California
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use Behat\Mink\Exception\ElementNotFoundException;
+use Behat\Step\Then;
+use Behat\Transformation\Transform;
+
+require_once(__DIR__ . '/../../../../lib/behat/behat_base.php');
+
+/**
+ * Steps definitions for testing banner alerts.
+ *
+ * @package theme_ucsf
+ * @copyright The Regents of the University of California
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class behat_theme_ucsf_behat_banneralerts extends behat_base {
+    /**
+     * Asserts that a banner alert of a given type with a given text is present on the page.
+     *
+     * @param bool $isdismissible Whether the given alert is dismissible or not.
+     * @param string $text The alert text.
+     * @param string $typeclass The alert type.
+     */
+    #[Then('/^I should see the (dismissible|non-dismissible) "([^"]+)" (announcement|info|warning) banner$/')]
+    public function i_should_see_the_banner(bool $isdismissible, string $text, string $typeclass): void {
+        $xpath = $this->get_xpath_to_banner($isdismissible, $text, $typeclass);
+        $this->execute("behat_general::should_exist", [$this->escape($xpath), "xpath_element"]);
+    }
+
+    /**
+     * Asserts that a banner alert of a given type with the given text is not present on the page.
+     *
+     * @param bool $isdismissible Whether the given alert is dismissible or not.
+     * @param string $text The alert text.
+     * @param string $typeclass The alert type.
+     */
+    #[Then("/^I shouldn't see the (dismissible|non-dismissible) \"([^\"]+)\" (announcement|info|warning) banner$/")]
+    public function i_shouldnt_see_the_banner(bool $isdismissible, string $text, string $typeclass): void {
+        $xpath = $this->get_xpath_to_banner($isdismissible, $text, $typeclass);
+        $this->execute("behat_general::should_not_exist", [$this->escape($xpath), "xpath_element"]);
+    }
+
+    /**
+     * Transforms the 'dismissible' keyword into TRUE and 'non-dismissible' into FALSE.
+     *
+     * @param string $str The keyword
+     * @return bool TRUE if the given word was 'dismissible', otherwise FALSE.
+     */
+    #[Transform('/^(dismissible|non-dismissible)$/')]
+    public function transform_dismissible_keywords_to_boolean(string $str): bool {
+        return 'dismissible' === $str;
+    }
+
+    /**
+     * Maps the given alert type to a CSS class.
+     *
+     * @param string $str The alert type.
+     * @return string The mapped CSS class.
+     */
+    #[Transform('/^(announcement|info|warning)$/')]
+    public function transform_alert_types_to_css_class_names(string $str): string {
+        return match ($str) {
+            'announcement' => 'alert-warning',
+            'info' => 'alert-info',
+            'warning' => 'alert-danger',
+        };
+    }
+
+    /**
+     * Dismisses a banner alert with the given text.
+     * @param string $text The alert text.
+     */
+    #[Then('/^I dismiss the "([^"]+)" banner$/')]
+    public function i_dismiss_the_banner(string $text): void {
+        $xpath = "//div[contains(@class, 'ucsf-banneralerts-alert') and text()[normalize-space()='{$text}']]";
+        $xpath .= '/button';
+        $node = $this->find("xpath", $this->escape($xpath));
+        if (!$node) {
+            throw new ElementNotFoundException($this->getSession()->getDriver(), selector: $xpath);
+        }
+        $node->click();
+    }
+
+    /**
+     * Builds a xpath expression for finding a banner alert on the page by the given parameters.
+     *
+     * @param bool $isdismissible Whether the alert is dismissible or not.
+     * @param string $text The alert text.
+     * @param string $typeclass The alert type CSS class.
+     * @return string The generated xpath expression.
+     */
+    protected function get_xpath_to_banner(bool $isdismissible, string $text, string $typeclass): string {
+        $rhett = "//div[contains(@class, 'ucsf-banneralerts-alert')";
+        $rhett .= " and contains(@class, '{$typeclass}')";
+        if ($isdismissible) {
+            $rhett .= " and contains(@class, 'alert-dismissible')";
+        } else {
+            $rhett .= " and not(contains(@class, 'alert-dismissible'))";
+        }
+        // Since the alert element may contain a button (if its dismissible),
+        // we'll have to ignore the button's text when filtering for the alert's actual text.
+        // We also have to trim whitespace in order to get an exact match on it.
+        $rhett .= " and text()[normalize-space()='{$text}']";
+        $rhett .= ']';
+        return $rhett;
+    }
+}

--- a/tests/behat/theme_ucsf_banneralerts.feature
+++ b/tests/behat/theme_ucsf_banneralerts.feature
@@ -27,28 +27,28 @@ Feature: Banner Alerts display
       | alert1text             | eins | theme_ucsf |
 
     # Start on the frontpage.
-    Given I am on site homepage
+    When I am on site homepage
     Then I should see the non-dismissible "eins" info banner
     When I log in as "admin"
     # We're on the dashboard after logging in.
     Then I should see the dismissible "eins" info banner
     # Visit course pages and confirm that the banner is there.
-    Given I am on the "c1" "course" page
+    When I am on the "c1" "course" page
     Then I should see the dismissible "eins" info banner
-    Given I am on the "c2" "course" page
+    When I am on the "c2" "course" page
     Then I should see the dismissible "eins" info banner
-    Given I am on the "c3" "course" page
+    When I am on the "c3" "course" page
     Then I should see the dismissible "eins" info banner
-    Given I am on the "c4" "course" page
+    When I am on the "c4" "course" page
     Then I should see the dismissible "eins" info banner
     # Visit course category pages and confirm that the banner is there as well.
-    Given I am on the "cat2" "category" page
+    When I am on the "cat2" "category" page
     Then I should see the dismissible "eins" info banner
-    Given I am on the "subcat2.1" "category" page
+    When I am on the "subcat2.1" "category" page
     Then I should see the dismissible "eins" info banner
-    Given I am on the "cat3" "category" page
+    When I am on the "cat3" "category" page
     Then I should see the dismissible "eins" info banner
-    Given I am on the "subcat3.1" "category" page
+    When I am on the "subcat3.1" "category" page
     Then I should see the dismissible "eins" info banner
 
   Scenario: Dashboard-only banner
@@ -59,25 +59,25 @@ Feature: Banner Alerts display
       | alert1type             | info      | theme_ucsf |
       | alert1text             | eins      | theme_ucsf |
 
-    Given I am on site homepage
+    When I am on site homepage
     Then I shouldn't see the non-dismissible "eins" info banner
     When I log in as "admin"
     Then I should see the dismissible "eins" info banner
-    Given I am on the "c1" "course" page
+    When I am on the "c1" "course" page
     Then I shouldn't see the dismissible "eins" info banner
-    Given I am on the "c2" "course" page
+    When I am on the "c2" "course" page
     Then I shouldn't see the dismissible "eins" info banner
-    Given I am on the "c3" "course" page
+    When I am on the "c3" "course" page
     Then I shouldn't see the dismissible "eins" info banner
-    Given I am on the "c4" "course" page
+    When I am on the "c4" "course" page
     Then I shouldn't see the dismissible "eins" info banner
-    Given I am on the "cat2" "category" page
+    When I am on the "cat2" "category" page
     Then I shouldn't see the dismissible "eins" info banner
-    Given I am on the "subcat2.1" "category" page
+    When I am on the "subcat2.1" "category" page
     Then I shouldn't see the dismissible "eins" info banner
-    Given I am on the "cat3" "category" page
+    When I am on the "cat3" "category" page
     Then I shouldn't see the dismissible "eins" info banner
-    Given I am on the "subcat3.1" "category" page
+    When I am on the "subcat3.1" "category" page
     Then I shouldn't see the dismissible "eins" info banner
 
   Scenario: Course category banner
@@ -86,26 +86,26 @@ Feature: Banner Alerts display
       | recurring_alert1       | 1         | theme_ucsf |
       | alert1type             | info      | theme_ucsf |
       | alert1text             | eins      | theme_ucsf |
-    Given alert 1 targets course category "cat3"
-    When I am on site homepage
+    When alert 1 targets course category "cat3"
+    And I am on site homepage
     Then I shouldn't see the non-dismissible "eins" info banner
     When I log in as "admin"
     Then I shouldn't see the dismissible "eins" info banner
-    Given I am on the "c1" "course" page
+    When I am on the "c1" "course" page
     Then I shouldn't see the dismissible "eins" info banner
-    Given I am on the "c2" "course" page
+    When I am on the "c2" "course" page
     Then I shouldn't see the dismissible "eins" info banner
-    Given I am on the "c3" "course" page
+    When I am on the "c3" "course" page
     Then I should see the dismissible "eins" info banner
-    Given I am on the "c4" "course" page
+    When I am on the "c4" "course" page
     Then I should see the dismissible "eins" info banner
-    Given I am on the "cat2" "category" page
+    When I am on the "cat2" "category" page
     Then I shouldn't see the dismissible "eins" info banner
-    Given I am on the "subcat2.1" "category" page
+    When I am on the "subcat2.1" "category" page
     Then I shouldn't see the dismissible "eins" info banner
-    Given I am on the "cat3" "category" page
+    When I am on the "cat3" "category" page
     Then I should see the dismissible "eins" info banner
-    Given I am on the "subcat3.1" "category" page
+    When I am on the "subcat3.1" "category" page
     Then I should see the dismissible "eins" info banner
 
   Scenario: Alert levels are applied correctly
@@ -126,7 +126,7 @@ Feature: Banner Alerts display
       | alert3type             | error   | theme_ucsf |
       | alert3text             | drei    | theme_ucsf |
 
-    Given I am on site homepage
+    When I am on site homepage
     Then I should see the non-dismissible "eins" info banner
     And I should see the non-dismissible "zwei" announcement banner
     And I should see the non-dismissible "drei" warning banner
@@ -138,7 +138,7 @@ Feature: Banner Alerts display
       | categories_list_alert1 | 0    | theme_ucsf |
       | alert1type             | info | theme_ucsf |
       | alert1text             | eins | theme_ucsf |
-    Given I am on site homepage
+    When I am on site homepage
     Then I should see the non-dismissible "eins" info banner
     When I log in as "admin"
     Then I should see the dismissible "eins" info banner
@@ -333,7 +333,7 @@ Feature: Banner Alerts display
       | categories_list_alert1 | 0    | theme_ucsf |
       | alert1type             | info | theme_ucsf |
       | alert1text             | eins | theme_ucsf |
-    Given I log in as "admin"
+    When I log in as "admin"
     Then I should see the dismissible "eins" info banner
     When I dismiss the "eins" banner
     Then I shouldn't see the dismissible "eins" info banner

--- a/tests/behat/theme_ucsf_banneralerts.feature
+++ b/tests/behat/theme_ucsf_banneralerts.feature
@@ -80,6 +80,34 @@ Feature: Banner Alerts display
     Given I am on the "subcat3.1" "category" page
     Then I shouldn't see the dismissible "eins" info banner
 
+  Scenario: Course category banner
+    Given the following config values are set as admin:
+      | enable1alert           | 1         | theme_ucsf |
+      | recurring_alert1       | 1         | theme_ucsf |
+      | alert1type             | info      | theme_ucsf |
+      | alert1text             | eins      | theme_ucsf |
+    Given alert 1 targets course category "cat3"
+    When I am on site homepage
+    Then I shouldn't see the non-dismissible "eins" info banner
+    When I log in as "admin"
+    Then I shouldn't see the dismissible "eins" info banner
+    Given I am on the "c1" "course" page
+    Then I shouldn't see the dismissible "eins" info banner
+    Given I am on the "c2" "course" page
+    Then I shouldn't see the dismissible "eins" info banner
+    Given I am on the "c3" "course" page
+    Then I should see the dismissible "eins" info banner
+    Given I am on the "c4" "course" page
+    Then I should see the dismissible "eins" info banner
+    Given I am on the "cat2" "category" page
+    Then I shouldn't see the dismissible "eins" info banner
+    Given I am on the "subcat2.1" "category" page
+    Then I shouldn't see the dismissible "eins" info banner
+    Given I am on the "cat3" "category" page
+    Then I should see the dismissible "eins" info banner
+    Given I am on the "subcat3.1" "category" page
+    Then I should see the dismissible "eins" info banner
+
   Scenario: Alert levels are applied correctly
     Given the following config values are set as admin:
       | enable1alert           | 1       | theme_ucsf |

--- a/tests/behat/theme_ucsf_banneralerts.feature
+++ b/tests/behat/theme_ucsf_banneralerts.feature
@@ -39,7 +39,7 @@ Feature: Banner Alerts display
     When I log in as "admin"
     Then I should see the dismissible "eins" info banner
 
-  Scenario: Date-bound alert is only visible within its scheduled time window
+  Scenario Outline: Date-bound alert is visible within its scheduled time window
     # The banner is scheduled to be visible between 9:45am and 10:15am on July 1st 2026.
     Given the following config values are set as admin:
       | enable1alert           | 1          | theme_ucsf |
@@ -53,18 +53,40 @@ Feature: Banner Alerts display
       | categories_list_alert1 | 0          | theme_ucsf |
       | alert1type             | info       | theme_ucsf |
       | alert1text             | eins       | theme_ucsf |
-    When I am on site homepage
-    # We're outside the time window, a minute early - no banner on the page.
-    And the time is frozen at "2026-07-01 09:44:00"
-    Then I shouldn't see the non-dismissible "eins" info banner
-    # We're within the time window - the banner is on page.
-    And the time is frozen at "2026-07-01 10:00:00"
-    When I reload the page
+    When the time is frozen at "<date>"
+    And I am on site homepage
     Then I should see the non-dismissible "eins" info banner
-    # We're outside the time window again, this time a minute late - no banner on the page.
-    When the time is frozen at "2026-07-01 10:16:00"
-    When I reload the page
+
+    Examples:
+      | date             |
+      | 2026-07-01 09:45 |
+      | 2026-07-01 10:00 |
+      | 2026-07-01 10:15 |
+
+  Scenario Outline: Date-bound alert is not visible outside its scheduled time window
+    # The banner is scheduled to be visible between 9:45am and 10:15am on July 1st 2026.
+    Given the following config values are set as admin:
+      | enable1alert           | 1          | theme_ucsf |
+      | recurring_alert1       | 2          | theme_ucsf |
+      | start_date1            | 2026-07-01 | theme_ucsf |
+      | start_hour1            | 9          | theme_ucsf |
+      | start_minute1          | 45         | theme_ucsf |
+      | end_date1              | 2026-07-01 | theme_ucsf |
+      | end_hour1              | 10         | theme_ucsf |
+      | end_minute1            | 15         | theme_ucsf |
+      | categories_list_alert1 | 0          | theme_ucsf |
+      | alert1type             | info       | theme_ucsf |
+      | alert1text             | eins       | theme_ucsf |
+    When the time is frozen at "<date>"
+    And I am on site homepage
     Then I shouldn't see the non-dismissible "eins" info banner
+
+    Examples:
+      | date             |
+      | 2026-06-30 10:00 |
+      | 2026-07-01 09:44 |
+      | 2026-07-01 10:16 |
+      | 2026-07-02 10:00 |
 
   @javascript
   # A quick note on that `@javascript` tag.

--- a/tests/behat/theme_ucsf_banneralerts.feature
+++ b/tests/behat/theme_ucsf_banneralerts.feature
@@ -1,0 +1,59 @@
+@theme @theme_ucsf @theme_ucsf_banneralerts
+Feature: Banner Alerts display
+  In order stay informed
+  As a user
+  I should receive banner alert messages on pages
+
+  Scenario: Alert levels are applied correctly
+    Given the following config values are set as admin:
+      | enable1alert           | 1       | theme_ucsf |
+      | recurring_alert1       | 1       | theme_ucsf |
+      | categories_list_alert1 | 0       | theme_ucsf |
+      | alert1type             | info    | theme_ucsf |
+      | alert1text             | eins    | theme_ucsf |
+      | enable2alert           | 1       | theme_ucsf |
+      | recurring_alert2       | 1       | theme_ucsf |
+      | categories_list_alert2 | 0       | theme_ucsf |
+      | alert2type             | success | theme_ucsf |
+      | alert2text             | zwei    | theme_ucsf |
+      | enable3alert           | 1       | theme_ucsf |
+      | recurring_alert3       | 1       | theme_ucsf |
+      | categories_list_alert3 | 0       | theme_ucsf |
+      | alert3type             | error   | theme_ucsf |
+      | alert3text             | drei    | theme_ucsf |
+
+    Given I am on site homepage
+    Then I should see the non-dismissible "eins" info banner
+    And I should see the non-dismissible "zwei" announcement banner
+    And I should see the non-dismissible "drei" warning banner
+
+  Scenario: Alert is non-dismissible when logged out, but dismissible when logged in
+    Given the following config values are set as admin:
+      | enable1alert           | 1    | theme_ucsf |
+      | recurring_alert1       | 1    | theme_ucsf |
+      | categories_list_alert1 | 0    | theme_ucsf |
+      | alert1type             | info | theme_ucsf |
+      | alert1text             | eins | theme_ucsf |
+    Given I am on site homepage
+    Then I should see the non-dismissible "eins" info banner
+    When I log in as "admin"
+    Then I should see the dismissible "eins" info banner
+
+  @javascript
+  # A quick note on that `@javascript` tag.
+  # This scenario must be run in javascript mode.
+  # Otherwise, dismissing the alert wouldn't work, b/c the driver
+  # used in "normal" mode doesn't support clicking on arbitrary buttons.
+  Scenario: Dismiss a banner alert
+    Given the following config values are set as admin:
+      | enable1alert           | 1    | theme_ucsf |
+      | recurring_alert1       | 1    | theme_ucsf |
+      | categories_list_alert1 | 0    | theme_ucsf |
+      | alert1type             | info | theme_ucsf |
+      | alert1text             | eins | theme_ucsf |
+    Given I log in as "admin"
+    Then I should see the dismissible "eins" info banner
+    When I dismiss the "eins" banner
+    Then I shouldn't see the dismissible "eins" info banner
+    When I reload the page
+    Then I shouldn't see the dismissible "eins" info banner

--- a/tests/behat/theme_ucsf_banneralerts.feature
+++ b/tests/behat/theme_ucsf_banneralerts.feature
@@ -4,6 +4,82 @@ Feature: Banner Alerts display
   As a user
   I should receive banner alert messages on pages
 
+  Background:
+    Given the following "categories" exist:
+      | name                 | category | idnumber  | visible |
+      | Test Category 2      | 0        | cat2      | 1       |
+      | Test Subcategory 2.1 | cat2     | subcat2.1 | 1       |
+      | Test Category 3      |          | cat3      | 1       |
+      | Test Subcategory 3.1 | cat3     | subcat3.1 | 1       |
+    And the following "courses" exist:
+      | fullname      | shortname | category  | visible |
+      | Test Course 1 | c1        | cat2      | 1       |
+      | Test Course 2 | c2        | subcat2.1 | 1       |
+      | Test Course 3 | c3        | cat3      | 1       |
+      | Test Course 4 | c4        | subcat3.1 | 1       |
+
+  Scenario: Site-wide banner
+    Given the following config values are set as admin:
+      | enable1alert           | 1    | theme_ucsf |
+      | recurring_alert1       | 1    | theme_ucsf |
+      | categories_list_alert1 | 0    | theme_ucsf |
+      | alert1type             | info | theme_ucsf |
+      | alert1text             | eins | theme_ucsf |
+
+    # Start on the frontpage.
+    Given I am on site homepage
+    Then I should see the non-dismissible "eins" info banner
+    When I log in as "admin"
+    # We're on the dashboard after logging in.
+    Then I should see the dismissible "eins" info banner
+    # Visit course pages and confirm that the banner is there.
+    Given I am on the "c1" "course" page
+    Then I should see the dismissible "eins" info banner
+    Given I am on the "c2" "course" page
+    Then I should see the dismissible "eins" info banner
+    Given I am on the "c3" "course" page
+    Then I should see the dismissible "eins" info banner
+    Given I am on the "c4" "course" page
+    Then I should see the dismissible "eins" info banner
+    # Visit course category pages and confirm that the banner is there as well.
+    Given I am on the "cat2" "category" page
+    Then I should see the dismissible "eins" info banner
+    Given I am on the "subcat2.1" "category" page
+    Then I should see the dismissible "eins" info banner
+    Given I am on the "cat3" "category" page
+    Then I should see the dismissible "eins" info banner
+    Given I am on the "subcat3.1" "category" page
+    Then I should see the dismissible "eins" info banner
+
+  Scenario: Dashboard-only banner
+    Given the following config values are set as admin:
+      | enable1alert           | 1         | theme_ucsf |
+      | recurring_alert1       | 1         | theme_ucsf |
+      | categories_list_alert1 | dashboard | theme_ucsf |
+      | alert1type             | info      | theme_ucsf |
+      | alert1text             | eins      | theme_ucsf |
+
+    Given I am on site homepage
+    Then I shouldn't see the non-dismissible "eins" info banner
+    When I log in as "admin"
+    Then I should see the dismissible "eins" info banner
+    Given I am on the "c1" "course" page
+    Then I shouldn't see the dismissible "eins" info banner
+    Given I am on the "c2" "course" page
+    Then I shouldn't see the dismissible "eins" info banner
+    Given I am on the "c3" "course" page
+    Then I shouldn't see the dismissible "eins" info banner
+    Given I am on the "c4" "course" page
+    Then I shouldn't see the dismissible "eins" info banner
+    Given I am on the "cat2" "category" page
+    Then I shouldn't see the dismissible "eins" info banner
+    Given I am on the "subcat2.1" "category" page
+    Then I shouldn't see the dismissible "eins" info banner
+    Given I am on the "cat3" "category" page
+    Then I shouldn't see the dismissible "eins" info banner
+    Given I am on the "subcat3.1" "category" page
+    Then I shouldn't see the dismissible "eins" info banner
+
   Scenario: Alert levels are applied correctly
     Given the following config values are set as admin:
       | enable1alert           | 1       | theme_ucsf |

--- a/tests/behat/theme_ucsf_banneralerts.feature
+++ b/tests/behat/theme_ucsf_banneralerts.feature
@@ -27,7 +27,7 @@ Feature: Banner Alerts display
     And I should see the non-dismissible "zwei" announcement banner
     And I should see the non-dismissible "drei" warning banner
 
-  Scenario: Alert is non-dismissible when logged out, but dismissible when logged in
+  Scenario: Banner is non-dismissible when logged out, but dismissible when logged in
     Given the following config values are set as admin:
       | enable1alert           | 1    | theme_ucsf |
       | recurring_alert1       | 1    | theme_ucsf |
@@ -38,6 +38,33 @@ Feature: Banner Alerts display
     Then I should see the non-dismissible "eins" info banner
     When I log in as "admin"
     Then I should see the dismissible "eins" info banner
+
+  Scenario: Date-bound alert is only visible within its scheduled time window
+    # The banner is scheduled to be visible between 9:45am and 10:15am on July 1st 2026.
+    Given the following config values are set as admin:
+      | enable1alert           | 1          | theme_ucsf |
+      | recurring_alert1       | 2          | theme_ucsf |
+      | start_date1            | 2026-07-01 | theme_ucsf |
+      | start_hour1            | 9          | theme_ucsf |
+      | start_minute1          | 45         | theme_ucsf |
+      | end_date1              | 2026-07-01 | theme_ucsf |
+      | end_hour1              | 10         | theme_ucsf |
+      | end_minute1            | 15         | theme_ucsf |
+      | categories_list_alert1 | 0          | theme_ucsf |
+      | alert1type             | info       | theme_ucsf |
+      | alert1text             | eins       | theme_ucsf |
+    When I am on site homepage
+    # We're outside the time window, a minute early - no banner on the page.
+    And the time is frozen at "2026-07-01 09:44:00"
+    Then I shouldn't see the non-dismissible "eins" info banner
+    # We're within the time window - the banner is on page.
+    And the time is frozen at "2026-07-01 10:00:00"
+    When I reload the page
+    Then I should see the non-dismissible "eins" info banner
+    # We're outside the time window again, this time a minute late - no banner on the page.
+    When the time is frozen at "2026-07-01 10:16:00"
+    When I reload the page
+    Then I shouldn't see the non-dismissible "eins" info banner
 
   @javascript
   # A quick note on that `@javascript` tag.
@@ -55,5 +82,6 @@ Feature: Banner Alerts display
     Then I should see the dismissible "eins" info banner
     When I dismiss the "eins" banner
     Then I shouldn't see the dismissible "eins" info banner
+    # Reload the page, make sure the alert doesn't resurface.
     When I reload the page
     Then I shouldn't see the dismissible "eins" info banner

--- a/tests/behat/theme_ucsf_banneralerts.feature
+++ b/tests/behat/theme_ucsf_banneralerts.feature
@@ -88,6 +88,135 @@ Feature: Banner Alerts display
       | 2026-07-01 10:16 |
       | 2026-07-02 10:00 |
 
+  Scenario Outline: Daily alert is visible within its scheduled time window
+    # The banner is scheduled to be visible between 9:45am and 10:15am
+    # every day between on July 1st and July 3rd 2026.
+    Given the following config values are set as admin:
+      | enable1alert           | 1          | theme_ucsf |
+      | recurring_alert1       | 3          | theme_ucsf |
+      | start_date_daily1      | 2026-07-01 | theme_ucsf |
+      | start_hour_daily1      | 9          | theme_ucsf |
+      | start_minute_daily1    | 45         | theme_ucsf |
+      | end_date_daily1        | 2026-07-03 | theme_ucsf |
+      | end_hour_daily1        | 10         | theme_ucsf |
+      | end_minute_daily1      | 15         | theme_ucsf |
+      | categories_list_alert1 | 0          | theme_ucsf |
+      | alert1type             | info       | theme_ucsf |
+      | alert1text             | eins       | theme_ucsf |
+    When the time is frozen at "<date>"
+    And I am on site homepage
+    Then I should see the non-dismissible "eins" info banner
+
+    Examples:
+      | date             |
+      | 2026-07-01 09:45 |
+      | 2026-07-01 10:00 |
+      | 2026-07-01 10:15 |
+      | 2026-07-02 09:45 |
+      | 2026-07-02 10:00 |
+      | 2026-07-02 10:15 |
+      | 2026-07-03 09:45 |
+      | 2026-07-03 10:00 |
+      | 2026-07-03 10:15 |
+
+  Scenario Outline: Daily alert is not visible outside its scheduled time window
+    # The banner is scheduled to be visible between 9:45am and 10:15am on July 1st 2026.
+    Given the following config values are set as admin:
+      | enable1alert           | 1          | theme_ucsf |
+      | recurring_alert1       | 2          | theme_ucsf |
+      | start_date1            | 2026-07-01 | theme_ucsf |
+      | start_hour1            | 9          | theme_ucsf |
+      | start_minute1          | 45         | theme_ucsf |
+      | end_date1              | 2026-07-01 | theme_ucsf |
+      | end_hour1              | 10         | theme_ucsf |
+      | end_minute1            | 15         | theme_ucsf |
+      | categories_list_alert1 | 0          | theme_ucsf |
+      | alert1type             | info       | theme_ucsf |
+      | alert1text             | eins       | theme_ucsf |
+    When the time is frozen at "<date>"
+    And I am on site homepage
+    Then I shouldn't see the non-dismissible "eins" info banner
+
+    Examples:
+      | date             |
+      | 2026-06-30 10:00 |
+      | 2026-07-01 09:44 |
+      | 2026-07-01 10:16 |
+      | 2026-07-02 09:44 |
+      | 2026-07-02 10:16 |
+      | 2026-07-03 09:44 |
+      | 2026-07-03 10:16 |
+      | 2026-07-04 10:00 |
+
+  Scenario Outline: Weekly alert is visible within its scheduled time window
+    # The banner is scheduled to be visible between 9:45am and 10:15am
+    # every Tuesday between on July 1st and July 10th 2026.
+    # Those Tuesdays are July 2nd and 9th.
+    Given the following config values are set as admin:
+      | enable1alert           | 1          | theme_ucsf |
+      | recurring_alert1       | 4          | theme_ucsf |
+      | start_date_weekly1     | 2026-07-01 | theme_ucsf |
+      | start_hour_weekly1     | 9          | theme_ucsf |
+      | start_minute_weekly1   | 45         | theme_ucsf |
+      | end_date_weekly1       | 2026-07-10 | theme_ucsf |
+      | end_hour_weekly1       | 10         | theme_ucsf |
+      | end_minute_weekly1     | 15         | theme_ucsf |
+      | show_week_day1         | 4          | theme_ucsf |
+      | categories_list_alert1 | 0          | theme_ucsf |
+      | alert1type             | info       | theme_ucsf |
+      | alert1text             | eins       | theme_ucsf |
+    When the time is frozen at "<date>"
+    And I am on site homepage
+    Then I should see the non-dismissible "eins" info banner
+
+    Examples:
+      | date             |
+      | 2026-07-02 09:45 |
+      | 2026-07-02 10:00 |
+      | 2026-07-02 10:15 |
+      | 2026-07-09 09:45 |
+      | 2026-07-09 10:00 |
+      | 2026-07-09 10:15 |
+
+  Scenario Outline: Weekly alert is not visible outside its scheduled time window
+    # The banner is scheduled to be visible between 9:45am and 10:15am
+    # every Tuesday between on July 1st and July 10th 2026.
+    # Those Tuesdays are July 2nd and 9th.
+    Given the following config values are set as admin:
+      | enable1alert           | 1          | theme_ucsf |
+      | recurring_alert1       | 4          | theme_ucsf |
+      | start_date_weekly1     | 2026-07-01 | theme_ucsf |
+      | start_hour_weekly1     | 9          | theme_ucsf |
+      | start_minute_weekly1   | 45         | theme_ucsf |
+      | end_date_weekly1       | 2026-07-10 | theme_ucsf |
+      | end_hour_weekly1       | 10         | theme_ucsf |
+      | end_minute_weekly1     | 15         | theme_ucsf |
+      | show_week_day1         | 4          | theme_ucsf |
+      | categories_list_alert1 | 0          | theme_ucsf |
+      | alert1type             | info       | theme_ucsf |
+      | alert1text             | eins       | theme_ucsf |
+    When the time is frozen at "<date>"
+    And I am on site homepage
+    Then I shouldn't see the non-dismissible "eins" info banner
+
+    Examples:
+      | date             |
+      | 2026-06-25 10:00 |
+      | 2026-07-01 10:00 |
+      | 2026-07-02 09:44 |
+      | 2026-07-02 10:16 |
+      | 2026-07-03 10:00 |
+      | 2026-07-04 10:00 |
+      | 2026-07-05 10:00 |
+      | 2026-07-06 10:00 |
+      | 2026-07-07 10:00 |
+      | 2026-07-08 10:00 |
+      | 2026-07-09 09:44 |
+      | 2026-07-09 10:16 |
+      | 2026-07-10 10:00 |
+      | 2026-07-11 10:00 |
+      | 2026-07-17 10:00 |
+
   @javascript
   # A quick note on that `@javascript` tag.
   # This scenario must be run in javascript mode.


### PR DESCRIPTION
refs #181 

in addition to the added tests, i want to point out that this plugin is now using Moodle's [Clock API](https://moodledev.io/docs/5.1/apis/core/clock) instead of PHP's datetime methods. 
This has the benefit that we can "freeze" time in our test coverage so we can effectively test date-bound alerts.