### PR TITLE
underlines troubleshooting link 

### DIFF
--- a/scss/post.scss
+++ b/scss/post.scss
@@ -66,6 +66,7 @@ $frontpage-content-maxwidth: 1200px !default;
 
     .troubleshooting {
         color: #616161;
+        text-decoration: underline;
 
         &:active,
         &:focus,

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_ucsf';
-$plugin->version = 2026041705;
+$plugin->version = 2026041706;
 $plugin->release = 'v5.1.5';
 $plugin->requires = 2025092600;
 $plugin->supported = [501, 501];


### PR DESCRIPTION
refs CLEM-110

<img width="796" height="818" alt="image" src="https://github.com/user-attachments/assets/185f2e94-fdbf-455a-b943-f93b764bc648" />
